### PR TITLE
Fix a service configuration elasticsearch.xml

### DIFF
--- a/src/Resources/config/services/integrations/elasticsearch.xml
+++ b/src/Resources/config/services/integrations/elasticsearch.xml
@@ -35,7 +35,7 @@
         <service id="bitbag_sylius_catalog_plugin.catalog_rule_checker.elasticsearch.by_name" class="BitBag\SyliusCatalogPlugin\Checker\Rule\Elasticsearch\ProductNameRule">
             <tag name="bitbag_sylius_catalog_plugin.catalog_rule_checker" type="sort_by_name" label="bitbag_sylius_catalog_plugin.ui.form.catalog_rule.sort_by_name" form-type="BitBag\SyliusCatalogPlugin\Form\Type\ProductNameConfigurationType"/>
             <argument type="service" id="sylius.context.locale" />
-            <argument>%bitbag_es_shop_name_property_prefix%</argument>
+            <argument type="service" id="bitbag_sylius_elasticsearch_plugin.property_name_resolver.name" />
         </service>
 
         <service id="bitbag_sylius_catalog_plugin.catalog_rule_checker.elasticsearch.by_price" class="BitBag\SyliusCatalogPlugin\Checker\Rule\Elasticsearch\PriceRule">


### PR DESCRIPTION
Fix crash on Symfony Service Container build.

`BitBag\SyliusCatalogPlugin\Checker\Rule\Elasticsearch\ProductNameRule` requires `$productNameNameResolver` as instance of `ConcatedNameResolverInterface`. But (probably from a historical reason) is configured to get just `%bitbag_es_shop_name_property_prefix%`.

Hint: I would recommend to add `tests/Application/bin/console lint:container` as new test step to reveal such configuration mistakes.